### PR TITLE
Upgrade the checkout action to v3

### DIFF
--- a/perl-module-macos.yml
+++ b/perl-module-macos.yml
@@ -38,7 +38,7 @@ jobs:
     perl:
         runs-on: macOS-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Platform check
               run: uname -a
             - name: Set up Perl

--- a/perl-module-release.yml
+++ b/perl-module-release.yml
@@ -21,7 +21,7 @@ jobs:
         container:
             image: perl:${{ matrix.perl-version }}
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 # Some older versions of Perl have trouble with hostnames in certs. I
 # haven't figured out why.
             - name: Setup environment

--- a/perl-module-ubuntu.yml
+++ b/perl-module-ubuntu.yml
@@ -60,7 +60,7 @@ jobs:
         container:
             image: perl:${{ matrix.perl-version }}
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Platform check
               run: uname -a
             - name: Perl version check

--- a/perl-module-windows.yml
+++ b/perl-module-windows.yml
@@ -44,7 +44,7 @@ jobs:
                 - windows-2019
                 - windows-2022
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Set up Perl
               run: |
                 choco install strawberryperl


### PR DESCRIPTION
the v2 action went away when GitHub killed Node 12.